### PR TITLE
Fix extension errors

### DIFF
--- a/invoice.js
+++ b/invoice.js
@@ -17,7 +17,7 @@
  *
  * @license GPL-3.0+ <http://spdx.org/licenses/GPL-3.0+>
  */
- 
+
 var receiptLayout = '<div id="openai_content"><span class="openai_ali">AliExpress</span>' +
 '<div class="openai_invoice_storename">Store Name: <span class="openai_store"></span></div>' +
 '<div class="openai_invoice_billto"><u>Bill to</u></div>' +
@@ -80,8 +80,8 @@ function main() {
 	getClass("openai_paydate", 0).innerHTML = getClass("pay-c4", 2).innerHTML.trim();
 
 	var prods = document.getElementsByClassName("order-bd");
-	for (var key in prods) {
-		m = prods[key].cloneNode(true)
+	for (let prod of prods) {
+		m = prod.cloneNode(true)
 		m.className = "openai_tr";
 		document.getElementById("openai_ProductTable").appendChild(m);
 	}

--- a/manifest.json
+++ b/manifest.json
@@ -3,11 +3,11 @@
 
 	"name": "Open AliExpress Invoice Generator",
 	"description": "This interface lets the user generate invoices from the order made on AliExpress",
-	"version": "0.18.3.3",	
+	"version": "0.19.10.7",	
 
 	"icons": {
-		"16": "icons/16.png", 
-		"48": "icons/48.png", 
+		"16": "icons/16.png",
+		"48": "icons/48.png",
 		"128": "icons/128.png"
 	},
 	"content_scripts": [


### PR DESCRIPTION
The chrome extension view showed some errors, which were due to a HTMLCollection being returned by getElementsByClassName, and the for/in loop not handling them properly. This should fix that.